### PR TITLE
Normalize CSV port parsing and default blank ports to 22

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ def parse_csv_devices(csv_content: str) -> List[DeviceInput]:
 
         device = DeviceInput(
             host=row["host"].strip(),
-            port=int(row.get("port", "22")),
+            port=int(row.get("port", "").strip() or "22"),
             device_type=row["device_type"].strip(),
             username=row["username"].strip(),
             password=row["password"].strip(),


### PR DESCRIPTION
### Motivation
- Ensure CSV `port` values are normalized before conversion to `int` to avoid errors on blank or whitespace-only values.
- Default blank `port` entries to `"22"` so devices without an explicit port still produce a valid `DeviceInput`.
- Preserve existing behavior for explicit numeric `port` values.
- Guarantee `DeviceInput` objects are returned even when `port` is blank.

### Description
- Update `parse_csv_devices` to use `int(row.get("port", "").strip() or "22")` when constructing `DeviceInput`.
- Change is localized to `backend/app/main.py` and only affects CSV parsing logic.
- Explicit numeric `port` values are still passed through to `int` unchanged.
- No other endpoints or job/device handling behavior were modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630119e24c8330815d63283db4e8b4)