### PR TITLE
Update devices import docs to specify CSV (text/plain)

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -95,7 +95,7 @@ tests/
 All required endpoints implemented:
 
 ### POST /api/devices/import
-- ✅ Accepts CSV (text/plain or JSON)
+- ✅ Accepts CSV (text/plain)
 - ✅ Returns devices with connection_ok status
 - ✅ Lightweight connection test (auth only)
 - ✅ Only connection_ok=true devices stored


### PR DESCRIPTION
### Motivation
- Align the implementation documentation with the actual API behavior for the devices import endpoint.
- Remove an incorrect mention of JSON support which could mislead clients.
- Ensure the documented content type matches the backend contract.

### Description
- Updated `IMPLEMENTATION.md` to replace "Accepts CSV (text/plain or JSON)" with "Accepts CSV (text/plain)" for `POST /api/devices/import`.
- Verified the backend endpoint signature in `backend/app/main.py` uses `Body(..., media_type="text/plain")` to accept CSV input.
- No code behavior was changed; this is a documentation-only update.

### Testing
- No automated tests were run because this is a documentation-only change.
- Verification consisted of inspecting `backend/app/main.py` to confirm the documented media type matches the implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963011c793483308df0ed42a5198fe4)