### PR TITLE
Add pause/resume/terminate job controls and WebUI actions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,3 +1,22 @@
+<!--
+  Copyright 2026 icecake0141
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was created or modified with the assistance of an AI (Large Language Model).
+  Review required for correctness, security, and licensing.
+-->
 # ネットワークデバイス設定管理ツール
 
 SSH経由で複数のネットワークデバイスに対して複数行の設定コマンドを適用するための、最小限のシングルプロセスWebアプリケーション（MVP）です。
@@ -128,6 +147,7 @@ CSV内容を貼り付けてデバイスをインポートし検証します。�
 - ライブログストリーミング
 - 設定の変更前後の差分
 - エラーレポート
+- 実行中ジョブの一時停止・再開・終了ボタン（Docker環境でも利用可能）
 
 ## 🔌 APIドキュメント
 
@@ -196,6 +216,42 @@ host,port,device_type,username,password,name,verify_cmds
 {
   "job_id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "queued"
+}
+```
+
+### POST /api/jobs/{job_id}/pause
+
+実行中のジョブを一時停止します。再開するまで新しいデバイスには実行されません。
+
+**レスポンス**:
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "paused"
+}
+```
+
+### POST /api/jobs/{job_id}/resume
+
+一時停止中のジョブを再開します。
+
+**レスポンス**:
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "running"
+}
+```
+
+### POST /api/jobs/{job_id}/terminate
+
+実行中のジョブを終了し、未処理デバイスをキャンセルします。実行中のデバイスは安全な区切りで停止を試みます。
+
+**レスポンス**:
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "cancelled"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!--
+  Copyright 2026 icecake0141
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was created or modified with the assistance of an AI (Large Language Model).
+  Review required for correctness, security, and licensing.
+-->
 # Network Device Configuration Manager
 
 A minimal single-process web application (MVP) for applying multi-line configuration commands to multiple network devices over SSH.
@@ -128,6 +147,7 @@ Real-time monitoring with:
 - Live log streaming
 - Pre/post configuration diffs
 - Error reporting
+- Pause, resume, and terminate controls for in-flight jobs (works in Docker deployments as well)
 
 ## 🔌 API Documentation
 
@@ -196,6 +216,42 @@ Create and execute a configuration job.
 {
   "job_id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "queued"
+}
+```
+
+### POST /api/jobs/{job_id}/pause
+
+Pause a running job. New devices will not start until the job is resumed.
+
+**Response**:
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "paused"
+}
+```
+
+### POST /api/jobs/{job_id}/resume
+
+Resume a paused job.
+
+**Response**:
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "running"
+}
+```
+
+### POST /api/jobs/{job_id}/terminate
+
+Terminate a running job and cancel pending devices. Active device sessions are asked to stop at the next safe checkpoint.
+
+**Response**:
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "cancelled"
 }
 ```
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,3 +1,20 @@
+# Copyright 2026 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
 """Pydantic models for the network device configuration application."""
 
 from typing import Optional, List, Dict
@@ -93,6 +110,7 @@ class JobStatus(str, Enum):
 
     QUEUED = "queued"
     RUNNING = "running"
+    PAUSED = "paused"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
@@ -171,4 +189,11 @@ class WSJobCompleteMessage(WSMessage):
     """WebSocket job complete message."""
 
     type: str = "job_complete"
+    status: JobStatus
+
+
+class WSJobStatusMessage(WSMessage):
+    """WebSocket job status message."""
+
+    type: str = "job_status"
     status: JobStatus

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,3 +1,22 @@
+<!--
+  Copyright 2026 icecake0141
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was created or modified with the assistance of an AI (Large Language Model).
+  Review required for correctness, security, and licensing.
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -251,6 +270,25 @@
         
         .info-text {
             color: #17a2b8;
+        }
+
+        .job-actions {
+            display: flex;
+            gap: 10px;
+            margin-top: 15px;
+            flex-wrap: wrap;
+        }
+
+        .job-actions button {
+            min-width: 110px;
+        }
+
+        .job-actions .danger {
+            background: #dc3545;
+        }
+
+        .job-actions .danger:hover {
+            background: #c82333;
         }
     </style>
 </head>


### PR DESCRIPTION
### Motivation
- Provide operators the ability to pause, resume, and terminate in-flight jobs from the WebUI or API so environments can be cleaned up without CLI steps and behavior works when running in Docker.
- Make job execution cancellation-safe so active and pending device tasks can be safely stopped or paused at known checkpoints.

### Description
- Add job control primitives (`JobControl`), `pause_job`, `resume_job`, and `terminate_job` to the manager and thread flow in `backend/app/job_manager.py`, and expose endpoints `POST /api/jobs/{job_id}/pause`, `/resume`, `/terminate` in `backend/app/main.py`.
- Make SSH execution cancellation-aware by adding a `cancel_event` parameter and early-cancel checks to `execute_device_commands` in `backend/app/ssh_executor.py` so running sessions are asked to stop at safe checkpoints.
- Add WebUI controls and state handling in `frontend/public/app.js` and UI styles in `frontend/public/index.html` to show Pause/Resume/Terminate buttons and react to `job_status` WebSocket messages.
- Update models, documentation and tests; files modified (LLM-assisted): `README.md`, `README.ja.md`, `backend/app/job_manager.py`, `backend/app/main.py`, `backend/app/models.py`, `backend/app/ssh_executor.py`, `frontend/public/app.js`, `frontend/public/index.html`, and `tests/unit/test_job_manager.py`; this work was produced with LLM assistance and requires human review for correctness and security.

### Testing
- Ran formatter with `cd backend && black app/ ../tests/` which completed successfully and reformatted `backend/app/job_manager.py` as reported.
- Ran unit tests with `cd /workspace/nw-edit && pytest tests/unit -v` which succeeded (`20 passed`).
- Ran static type checks with `cd /workspace/nw-edit && mypy backend/app` which passed after fixes were applied.
- Attempted lint and pre-commit validation with `cd backend && flake8 app/ ../tests/ --max-line-length=120 --extend-ignore=E203,W503` and `pre-commit run --all-files` but those tools were not available in the environment (commands reported as not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966fcb863cc833089262b464880b741)