### PR TITLE
Darken the prod warning overlay

### DIFF
--- a/frontend_v2/public/index.html
+++ b/frontend_v2/public/index.html
@@ -114,10 +114,10 @@ You may obtain a copy of the License at
       background:
         repeating-linear-gradient(
           135deg,
-          rgba(255, 176, 64, 0.14) 0px,
-          rgba(255, 176, 64, 0.14) 20px,
-          rgba(20, 20, 20, 0.05) 20px,
-          rgba(20, 20, 20, 0.05) 38px
+          rgba(255, 176, 64, 0.22) 0px,
+          rgba(255, 176, 64, 0.22) 20px,
+          rgba(20, 20, 20, 0.08) 20px,
+          rgba(20, 20, 20, 0.08) 38px
         );
     }
     .prod-warning-overlay.active {
@@ -127,7 +127,7 @@ You may obtain a copy of the License at
       position: absolute;
       inset: 0;
       font-weight: 700;
-      color: rgba(110, 54, 0, 0.3);
+      color: rgba(110, 54, 0, 0.42);
       letter-spacing: 0.04em;
       font-size: clamp(11px, 1.1vw, 16px);
       text-transform: uppercase;


### PR DESCRIPTION
## Summary
- darken the production warning overlay stripes shown when a selected host has `prod=true`
- darken the overlay label text to improve visibility without changing shared warning styles
- limit the change to the frontend CSS in `frontend_v2/public/index.html`

## Rationale
The existing production overlay was too subtle when production hosts were selected. This change increases the warning presence slightly while keeping the rest of the warning UI unchanged.

## Testing
- `make check`
- `make typecheck`
- `make precommit`

## Docs
- No documentation changes required because behavior and interfaces are unchanged.

## Compatibility
- No API, CSV schema, or JavaScript interface changes.
- No migration steps required.

## LLM Involvement
- Files modified with LLM assistance: `frontend_v2/public/index.html`
- Human review: maintainer review is still required before merge.

## PR Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: maximum available pass (command: `make check`)
- [x] Tests passing locally (command: `make check`)
- [x] Static analysis/type checks passing (command: `make typecheck`)
- [x] Formatting applied (command: `make precommit`)
- [x] Pre-commit hooks passing
- [x] CI expected to pass
- [x] No merge conflicts with base branch
- [x] Documentation updated (README, docs/, examples) not required
- [x] Changelog/version updated if applicable not required
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description
