### PR TITLE
Add app state reset flow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -97,6 +97,18 @@ make check-integration
   - `Sequential (1 device at a time)`: `concurrency_limit=1` を強制し、入力欄は無効化されます
 - バックエンドAPIの変更はなく、方式の差分はフロントエンドで `concurrency_limit` に反映します。
 
+## アプリ状態初期化（v2）
+
+- Import画面の `Reset App State` で、プロセス再起動なしに揮発状態を初期化できます。
+- 初期化対象:
+  - import済みデバイス
+  - ジョブ履歴
+  - バッファ済みイベントと実行結果
+  - 画面上の一時入力/選択状態
+- 保存済み実行プリセットは `NW_EDIT_V2_PRESET_FILE` に残ります。
+- バックエンドAPI: `POST /api/v2/app/reset`
+- `queued` / `running` / `paused` のジョブがある場合は `HTTP 409` で拒否されます。
+
 ## ドキュメント
 
 - ドキュメント一覧（英日）: [docs/INDEX.ja.md](docs/INDEX.ja.md)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ make check-integration
   - `Sequential (1 device at a time)` forces `concurrency_limit=1` and disables the input
 - No backend API changes were added; strategy is mapped only to `concurrency_limit`.
 
+## App state reset (v2)
+
+- Import page provides `Reset App State` to clear volatile runtime state without restarting the process.
+- Reset removes:
+  - imported devices
+  - job history
+  - buffered events and run results
+  - temporary UI input and selection state
+- Reset keeps saved execution presets in `NW_EDIT_V2_PRESET_FILE`.
+- Backend API: `POST /api/v2/app/reset`
+- If any job is `queued`, `running`, or `paused`, reset is rejected with `HTTP 409`.
+
 ## Documentation
 
 - Full index (EN/JA): [docs/INDEX.md](docs/INDEX.md)

--- a/backend_v2/app/api/main.py
+++ b/backend_v2/app/api/main.py
@@ -30,6 +30,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
 from backend_v2.app.api.schemas import (
+    AppResetCountsResponse,
+    AppResetResponse,
     ActiveJobResponse,
     CreateJobRequest,
     DeviceImportResponse,
@@ -508,6 +510,31 @@ def list_devices() -> list[DeviceProfileResponse]:
     ]
 
 
+@app.post("/api/v2/app/reset", response_model=AppResetResponse)
+def reset_app_state() -> AppResetResponse:
+    """Clear volatile in-memory application state."""
+    jobs = store.list()
+    active_jobs = [
+        job
+        for job in jobs
+        if job.status in {JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.PAUSED}
+    ]
+    if active_jobs:
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot reset app state while a job is queued, running, or paused",
+        )
+
+    cleared = AppResetCountsResponse(
+        devices=device_store.clear(),
+        jobs=store.clear(),
+        events=event_store.clear(),
+        run_results=run_store.clear(),
+        controls=control_store.clear(),
+    )
+    return AppResetResponse(reset=True, cleared=cleared)
+
+
 @app.post("/api/v2/commands/exec", response_model=StatusCommandResponse)
 def execute_status_command(payload: StatusCommandRequest) -> StatusCommandResponse:
     """Execute read-only status commands on an imported device."""
@@ -640,6 +667,9 @@ def get_job(job_id: str) -> JobResponse:
 @app.get("/api/v2/jobs/{job_id}/events", response_model=list[ExecutionEventResponse])
 def list_job_events(job_id: str) -> list[ExecutionEventResponse]:
     """List buffered execution events for a job."""
+    job = store.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
     events = event_store.list_events(job_id=job_id)
     return [
         ExecutionEventResponse(

--- a/backend_v2/app/api/schemas.py
+++ b/backend_v2/app/api/schemas.py
@@ -194,3 +194,20 @@ class RuntimeModesResponse(BaseModel):
 
     worker_mode: str
     validator_mode: str
+
+
+class AppResetCountsResponse(BaseModel):
+    """Counts of cleared in-memory app state."""
+
+    devices: int
+    jobs: int
+    events: int
+    run_results: int
+    controls: int
+
+
+class AppResetResponse(BaseModel):
+    """App reset response payload."""
+
+    reset: bool
+    cleared: AppResetCountsResponse

--- a/backend_v2/app/infrastructure/in_memory_control_store.py
+++ b/backend_v2/app/infrastructure/in_memory_control_store.py
@@ -40,3 +40,9 @@ class InMemoryControlStore:
     def get(self, job_id: str) -> ExecutionControl | None:
         with self._lock:
             return self._controls.get(job_id)
+
+    def clear(self) -> int:
+        with self._lock:
+            cleared = len(self._controls)
+            self._controls = {}
+            return cleared

--- a/backend_v2/app/infrastructure/in_memory_device_store.py
+++ b/backend_v2/app/infrastructure/in_memory_device_store.py
@@ -45,3 +45,9 @@ class InMemoryDeviceStore:
                 if device.key == key:
                     return device
         return None
+
+    def clear(self) -> int:
+        with self._lock:
+            cleared = len(self._devices)
+            self._devices = []
+            return cleared

--- a/backend_v2/app/infrastructure/in_memory_event_store.py
+++ b/backend_v2/app/infrastructure/in_memory_event_store.py
@@ -41,3 +41,9 @@ class InMemoryEventStore(EventPublisher):
     def event_count(self, job_id: str) -> int:
         with self._lock:
             return len(self._events_by_job.get(job_id, []))
+
+    def clear(self) -> int:
+        with self._lock:
+            cleared = sum(len(events) for events in self._events_by_job.values())
+            self._events_by_job = {}
+            return cleared

--- a/backend_v2/app/infrastructure/in_memory_job_store.py
+++ b/backend_v2/app/infrastructure/in_memory_job_store.py
@@ -42,3 +42,9 @@ class InMemoryJobStore:
     def list(self) -> list[JobRecord]:
         with self._lock:
             return list(self._jobs.values())
+
+    def clear(self) -> int:
+        with self._lock:
+            cleared = len(self._jobs)
+            self._jobs = {}
+            return cleared

--- a/backend_v2/app/infrastructure/in_memory_run_store.py
+++ b/backend_v2/app/infrastructure/in_memory_run_store.py
@@ -38,3 +38,9 @@ class InMemoryRunStore:
     def get(self, job_id: str) -> JobRunSummary | None:
         with self._lock:
             return self._latest_by_job.get(job_id)
+
+    def clear(self) -> int:
+        with self._lock:
+            cleared = len(self._latest_by_job)
+            self._latest_by_job = {}
+            return cleared

--- a/backend_v2/tests/unit/test_api_main.py
+++ b/backend_v2/tests/unit/test_api_main.py
@@ -78,16 +78,11 @@ def reset_in_memory_runtime_state():
             for job_id, thread in api_main.run_coordinator._threads.items()
             if thread.is_alive()
         }
-    with api_main.store._lock:
-        api_main.store._jobs.clear()
-    with api_main.device_store._lock:
-        api_main.device_store._devices.clear()
-    with api_main.event_store._lock:
-        api_main.event_store._events_by_job.clear()
-    with api_main.run_store._lock:
-        api_main.run_store._latest_by_job.clear()
-    with api_main.control_store._lock:
-        api_main.control_store._controls.clear()
+    api_main.store.clear()
+    api_main.device_store.clear()
+    api_main.event_store.clear()
+    api_main.run_store.clear()
+    api_main.control_store.clear()
     api_main.engine.worker = api_main.SimulatedDeviceWorker()
     api_main.device_import_service.validator = api_main.SimulatedConnectionValidator()
     yield
@@ -781,6 +776,106 @@ def test_presets_crud_and_duplicate_conflict():
     models = client.get("/api/v2/presets/os-models")
     assert models.status_code == 200
     assert "cisco_ios" in models.json()
+
+
+def test_app_reset_clears_volatile_state_but_keeps_presets():
+    client = TestClient(app)
+    preset_name = f"reset-keep-{time.time_ns()}"
+    preset = client.post(
+        "/api/v2/presets",
+        json={
+            "name": preset_name,
+            "os_model": "cisco_ios",
+            "commands": ["show clock"],
+            "verify_commands": [],
+        },
+    )
+    assert preset.status_code == 200
+
+    import_devices_for_run(
+        client,
+        ["10.20.0.1,22,cisco_ios,admin,pass,edge-a,show run,"],
+    )
+    create = client.post(
+        "/api/v2/jobs",
+        json={"job_name": "reset-me", "creator": "tester"},
+    )
+    assert create.status_code == 200
+    job_id = create.json()["job_id"]
+
+    run = client.post(
+        f"/api/v2/jobs/{job_id}/run",
+        json={
+            "commands": ["show version"],
+            "imported_device_keys": ["10.20.0.1:22"],
+            "canary": {"host": "10.20.0.1", "port": 22},
+        },
+    )
+    assert run.status_code == 200
+
+    reset = client.post("/api/v2/app/reset")
+    assert reset.status_code == 200
+    assert reset.json()["reset"] is True
+    assert reset.json()["cleared"]["devices"] == 1
+    assert reset.json()["cleared"]["jobs"] == 1
+    assert reset.json()["cleared"]["events"] > 0
+    assert reset.json()["cleared"]["run_results"] == 1
+    assert reset.json()["cleared"]["controls"] == 1
+
+    listed_devices = client.get("/api/v2/devices")
+    assert listed_devices.status_code == 200
+    assert listed_devices.json() == []
+
+    listed_jobs = client.get("/api/v2/jobs")
+    assert listed_jobs.status_code == 200
+    assert listed_jobs.json() == []
+
+    active = client.get("/api/v2/jobs/active")
+    assert active.status_code == 200
+    assert active.json() == {"active": False, "job": None}
+
+    events = client.get(f"/api/v2/jobs/{job_id}/events")
+    assert events.status_code == 404
+
+    result = client.get(f"/api/v2/jobs/{job_id}/result")
+    assert result.status_code == 404
+
+    listed_presets = client.get("/api/v2/presets?os_model=cisco_ios")
+    assert listed_presets.status_code == 200
+    assert any(item["name"] == preset_name for item in listed_presets.json())
+
+
+def test_app_reset_returns_409_when_active_job_exists(monkeypatch):
+    client = TestClient(app)
+    monkeypatch.setenv("NW_EDIT_V2_SIMULATED_DELAY_MS", "700")
+    import_devices_for_run(
+        client,
+        [
+            "10.20.1.1,22,cisco_ios,admin,pass,edge-a,show run,",
+            "10.20.1.2,22,cisco_ios,admin,pass,edge-b,show run,",
+        ],
+    )
+    create = client.post(
+        "/api/v2/jobs",
+        json={"job_name": "reset-blocked", "creator": "tester"},
+    )
+    assert create.status_code == 200
+    job_id = create.json()["job_id"]
+
+    started = client.post(
+        f"/api/v2/jobs/{job_id}/run/async",
+        json={
+            "commands": ["show version"],
+            "imported_device_keys": ["10.20.1.1:22", "10.20.1.2:22"],
+            "canary": {"host": "10.20.1.1", "port": 22},
+            "concurrency_limit": 1,
+        },
+    )
+    assert started.status_code == 200
+
+    reset = client.post("/api/v2/app/reset")
+    assert reset.status_code == 409
+    assert "Cannot reset app state" in reset.json()["detail"]
 
 
 def test_run_with_imported_device_keys_limits_targets():

--- a/frontend_v2/public/api-client.js
+++ b/frontend_v2/public/api-client.js
@@ -26,6 +26,7 @@
  * @typedef {{ active: boolean, job?: JobSummary }} ActiveJobResponse
  * @typedef {{ worker_mode: string, validator_mode: string }} RuntimeModesResponse
  * @typedef {{ preset_id: string, name: string, os_model: string, commands: string[], verify_commands: string[], created_at: string, updated_at: string }} Preset
+ * @typedef {{ reset: boolean, cleared: { devices: number, jobs: number, events: number, run_results: number, controls: number } }} AppResetResponse
  */
 
 /**
@@ -131,6 +132,13 @@ export class NwEditApiClient {
   /** @returns {Promise<DeviceProfile[]>} */
   async listDevices() {
     return this.request("/api/v2/devices");
+  }
+
+  /** @returns {Promise<AppResetResponse>} */
+  async resetAppState() {
+    return this.request("/api/v2/app/reset", {
+      method: "POST",
+    });
   }
 
   /** @param {string} csvText @returns {Promise<ImportDevicesResponse>} */

--- a/frontend_v2/public/app.js
+++ b/frontend_v2/public/app.js
@@ -49,6 +49,7 @@ const resumeBtn = document.getElementById("resumeBtn");
 const cancelBtn = document.getElementById("cancelBtn");
 const clearBtn = document.getElementById("clearBtn");
 const importBtn = document.getElementById("importBtn");
+const resetAppStateBtn = document.getElementById("resetAppStateBtn");
 const refreshDevicesBtn = document.getElementById("refreshDevicesBtn");
 const listJobsBtn = document.getElementById("listJobsBtn");
 const refreshActiveBtn = document.getElementById("refreshActiveBtn");
@@ -98,6 +99,7 @@ let detailTargetDeviceKeys = [];
 let monitorResultLoading = false;
 let runBusy = false;
 let presetActionBusy = false;
+let resetAppStateBusy = false;
 /** @type {import("./api-client.js").JobDetail|null} */
 let activeBlockingJob = null;
 let reviewHostsCollapsed = false;
@@ -188,6 +190,14 @@ function resetImportStreamLog() {
   importStreamLogEl.textContent = "";
 }
 
+function closeActiveSocket() {
+  if (!activeSocket) {
+    return;
+  }
+  activeSocket.close();
+  activeSocket = null;
+}
+
 function setImportStreamVisible(visible) {
   if (!importLoadingEl || !importStreamLogEl) {
     return;
@@ -203,6 +213,9 @@ function isActiveRunBlocking(status) {
 function updateCreateActionState() {
   const blocked = Boolean(activeBlockingJob);
   runBtn.disabled = blocked || runBusy;
+  if (resetAppStateBtn) {
+    resetAppStateBtn.disabled = Boolean(runBusy || resetAppStateBusy);
+  }
   setPresetActionState();
   if (!activeJobBannerEl || !activeJobBannerTextEl) {
     return;
@@ -219,6 +232,9 @@ function updateCreateActionState() {
 
 function setImportInProgress(inProgress) {
   importBtn.disabled = inProgress;
+  if (resetAppStateBtn) {
+    resetAppStateBtn.disabled = Boolean(inProgress || runBusy || resetAppStateBusy);
+  }
   setImportStreamVisible(inProgress);
   if (inProgress) {
     importProgressEl.classList.remove("hidden");
@@ -680,6 +696,103 @@ function resetMonitorState() {
   monitorState.eventCount = 0;
 }
 
+function resetDetailState() {
+  detailTargetDeviceKeys = [];
+  detailMetaEl.textContent = "No job selected";
+  detailSummaryEl.textContent = "Select a job from history";
+  detailDevicesEl.innerHTML = "";
+  detailDataEl.textContent = "";
+}
+
+function resetHistoryState() {
+  historyEl.replaceChildren();
+  const div = document.createElement("div");
+  div.className = "history-item";
+  div.textContent = "no jobs yet";
+  historyEl.append(div);
+}
+
+function resetStatusCommandState() {
+  if (statusDeviceSelectEl) {
+    statusDeviceSelectEl.innerHTML = '<option value="">(select device)</option>';
+  }
+  if (statusCommandsEl) {
+    statusCommandsEl.value = statusCommandsEl.defaultValue;
+  }
+  if (statusOutputEl) {
+    statusOutputEl.textContent = statusOutputEl.defaultValue || "No output yet";
+  }
+}
+
+function resetCreateFormState() {
+  const jobNameEl = document.getElementById("jobName");
+  const creatorEl = document.getElementById("creator");
+  const globalVarsEl = document.getElementById("globalVars");
+  const commandsEl = document.getElementById("commands");
+  jobNameEl.value = jobNameEl.defaultValue;
+  creatorEl.value = creatorEl.defaultValue;
+  globalVarsEl.value = globalVarsEl.defaultValue;
+  commandsEl.value = commandsEl.defaultValue;
+  verifyCommandsEl.value = verifyCommandsEl.defaultValue;
+  verifyModeEl.value = verifyModeEl.defaultValue;
+  concurrencyLimitEl.value = concurrencyLimitEl.defaultValue;
+  staggerDelayEl.value = staggerDelayEl.defaultValue;
+  stopOnErrorEl.checked = stopOnErrorEl.defaultChecked;
+  enableRunConfirmationEl.checked = enableRunConfirmationEl.defaultChecked;
+  enablePresetModeEl.checked = enablePresetModeEl.defaultChecked;
+  presetPanelEl.classList.toggle("hidden", !enablePresetModeEl.checked);
+  osModelSelectEl.innerHTML = '<option value="">(not selected)</option>';
+  presetSelectEl.innerHTML = '<option value="">(not selected)</option>';
+  presetNameEl.value = presetNameEl.defaultValue;
+  canaryDeviceEl.innerHTML = '<option value="">(select canary)</option>';
+  postCanaryStrategyEls.forEach((el) => {
+    el.checked = el.defaultChecked;
+  });
+  reviewHostsCollapsed = false;
+  clearRunReview();
+  updateReviewHostListVisibility();
+  updatePostCanaryControls();
+  setPresetActionState();
+}
+
+function resetImportSectionState() {
+  const csvInputEl = document.getElementById("csvInput");
+  csvInputEl.value = csvInputEl.defaultValue;
+  clearImportError();
+  resetImportStreamLog();
+  setImportInProgress(false);
+  deviceCountEl.textContent = "imported devices: 0";
+}
+
+function resetFrontendAppState() {
+  closeActiveSocket();
+  importedDevices = [];
+  currentPresets = [];
+  prodDeviceKeys = new Set();
+  selectedJobId = null;
+  activeBlockingJob = null;
+  pendingRunReview = null;
+  resetMonitorState();
+  resetDetailState();
+  resetHistoryState();
+  resetStatusCommandState();
+  resetImportSectionState();
+  resetCreateFormState();
+  logEl.textContent = "";
+  activeSummaryEl.textContent = "active job: none";
+  monitorSummaryEl.textContent = "No active run selected";
+  monitorDevicesEl.innerHTML = "";
+  pauseBtn.disabled = true;
+  resumeBtn.disabled = true;
+  cancelBtn.disabled = true;
+  setStatus("ready");
+  renderImportedDeviceList();
+  populateStatusDeviceSelect();
+  refreshCanaryOptions();
+  refreshProdWarningOverlay();
+  updateCreateActionState();
+}
+
 function beginMonitor(job, targetDeviceKeys, canaryKey) {
   resetMonitorState();
   monitorState.job = { ...job };
@@ -977,7 +1090,8 @@ function switchPage(pageName) {
   refreshProdWarningOverlay();
 }
 
-async function refreshImportedDevices() {
+async function refreshImportedDevices(options = {}) {
+  const { log = true } = options;
   importedDevices = await client().listDevices();
   prodDeviceKeys = new Set(
     importedDevices
@@ -995,7 +1109,9 @@ async function refreshImportedDevices() {
   populateStatusDeviceSelect();
   refreshCanaryOptions();
   await refreshPresetOptions().catch((error) => appendLog(String(error)));
-  appendLog(`loaded imported devices: ${importedDevices.length}`);
+  if (log) {
+    appendLog(`loaded imported devices: ${importedDevices.length}`);
+  }
   refreshProdWarningOverlay();
 }
 
@@ -1425,6 +1541,31 @@ importBtn.addEventListener("click", async () => {
 
 refreshDevicesBtn.addEventListener("click", () => {
   refreshImportedDevices().catch((error) => appendLog(String(error)));
+});
+
+resetAppStateBtn?.addEventListener("click", async () => {
+  const confirmed = window.confirm(
+    "Reset app state?\n\nImported devices, input values, job history, run results, and temporary UI state will be cleared. Saved presets will be kept."
+  );
+  if (!confirmed) {
+    return;
+  }
+  resetAppStateBusy = true;
+  updateCreateActionState();
+  try {
+    await client().resetAppState();
+    resetFrontendAppState();
+    switchPage("import");
+    await refreshImportedDevices({ log: false });
+    await refreshJobs();
+    await refreshActive();
+    await refreshRuntimeModes();
+  } catch (error) {
+    appendLog(String(error));
+  } finally {
+    resetAppStateBusy = false;
+    updateCreateActionState();
+  }
 });
 
 listJobsBtn.addEventListener("click", () => {

--- a/frontend_v2/public/index.html
+++ b/frontend_v2/public/index.html
@@ -875,6 +875,7 @@ You may obtain a copy of the License at
       <div class="btn-row">
         <button class="secondary" id="importBtn" title="Import devices from the CSV text above and validate each row.">Import CSV</button>
         <button class="secondary" id="refreshDevicesBtn" title="Refresh the currently stored imported device list from backend memory.">Refresh Devices</button>
+        <button class="secondary" id="resetAppStateBtn" title="Clear imported devices, jobs, results, and current input state while keeping saved presets.">Reset App State</button>
       </div>
       <div class="import-status">
         <div id="importLoading" class="import-loading hidden" aria-live="polite">


### PR DESCRIPTION
## Summary
- add a backend `POST /api/v2/app/reset` endpoint to clear volatile runtime state while keeping saved presets
- add a frontend `Reset App State` action with confirmation and full in-browser state reset without reloading the page
- add API and UI support code plus regression coverage for reset success and active-job rejection paths

## Rationale
Operators need a safe way to return the app to a fresh-start state after importing devices or entering run inputs, without restarting the process or deleting saved presets.

## Tests added
- added API tests for successful reset of volatile state while preserving presets
- added API tests for rejecting reset when a job is queued, running, or paused

## Docs updated
- updated `README.md`
- updated `README.ja.md`

## Backward compatibility
- saved execution presets remain unchanged
- reset is rejected with `HTTP 409` when an active job exists

## LLM involvement
LLM-assisted files modified:
- `backend_v2/app/api/main.py`
- `backend_v2/app/api/schemas.py`
- `backend_v2/app/infrastructure/in_memory_control_store.py`
- `backend_v2/app/infrastructure/in_memory_device_store.py`
- `backend_v2/app/infrastructure/in_memory_event_store.py`
- `backend_v2/app/infrastructure/in_memory_job_store.py`
- `backend_v2/app/infrastructure/in_memory_run_store.py`
- `backend_v2/tests/unit/test_api_main.py`
- `frontend_v2/public/api-client.js`
- `frontend_v2/public/app.js`
- `frontend_v2/public/index.html`
- `README.md`
- `README.ja.md`

Human review performed:
- reviewed reset scope against current in-memory vs persisted state behavior
- reviewed API rejection behavior for active jobs
- reviewed frontend reset flow to avoid page reload and preserve saved presets

## Validation commands
- `PYTHON=python3.12 ./scripts/run_v2_checks.sh`
- `PYTHONPATH=. pytest backend_v2/tests/unit/test_api_main.py -q`

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files where applicable
- [x] Linting completed — result: pass (project uses pass/fail gates) (command: `PYTHON=python3.12 ./scripts/run_v2_checks.sh`)
- [x] Tests passing locally (command: `PYTHON=python3.12 ./scripts/run_v2_checks.sh`)
- [x] Static analysis/type checks passing (command: `PYTHON=python3.12 ./scripts/run_v2_checks.sh`)
- [x] Formatting applied (command: `PYTHON=python3.12 ./scripts/run_v2_checks.sh`)
- [x] Pre-commit hooks passing
- [x] CI expected to pass based on local checks
- [x] No merge conflicts with base branch at time of push
- [x] Documentation updated (`README.md`, `README.ja.md`)
- [ ] Changelog/version updated if applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description
