### PR TITLE
Add default CSV command variables

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -74,6 +74,9 @@ make check-integration
 - 実行コマンドで `{{var}}` プレースホルダを利用可能。
 - ジョブ単位の `global_vars` は `POST /api/v2/jobs` で指定。
 - ホスト単位の `host_vars` は CSV 取込の `host_vars` 列（JSONオブジェクト文字列）で指定。
+- インポートされた CSV 列は、ホスト単位のデフォルト変数として利用可能。組み込み変数は
+  `{{host}}`, `{{ip}}`, `{{hostname}}`, `{{port}}`, `{{device_type}}`, `{{name}}`,
+  `{{username}}`, `{{prod}}`。`password`, `host_vars`, `verify_cmds` は対象外。
 - 任意の CSV 列 `prod` で本番ホストを指定可能（`true` のとき本番、それ以外は `false` 扱い）。
 - 解決優先順位は `host_vars > global_vars`。
 - 未定義変数がある場合、デバイス実行前の preflight で `HTTP 400` を返す。

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ make check-integration
 - Use `{{var}}` placeholders in run commands.
 - Define job-level `global_vars` at `POST /api/v2/jobs`.
 - Define per-host `host_vars` in CSV import (`host_vars` column as JSON object string).
+- Imported CSV columns are available as default per-host variables. Built-ins include
+  `{{host}}`, `{{ip}}`, `{{hostname}}`, `{{port}}`, `{{device_type}}`, `{{name}}`,
+  `{{username}}`, and `{{prod}}`; `password`, `host_vars`, and `verify_cmds` are excluded.
 - Optional CSV column `prod` flags production hosts (`true` means production, others are treated as `false`).
 - Resolution order is `host_vars > global_vars`.
 - Missing variables fail preflight with `HTTP 400` before any device command runs.

--- a/backend_v2/app/application/device_import_service.py
+++ b/backend_v2/app/application/device_import_service.py
@@ -66,6 +66,7 @@ class DeviceImportService:
         "generic_linux": "linux",
         "generic-linux": "linux",
     }
+    _EXCLUDED_DEFAULT_VAR_COLUMNS = {"password", "host_vars", "verify_cmds"}
 
     def __init__(
         self, store: InMemoryDeviceStore, validator: DeviceConnectionValidator
@@ -84,6 +85,29 @@ class DeviceImportService:
     @staticmethod
     def _normalize_header_name(name: str) -> str:
         return name.strip().lower()
+
+    def _default_host_vars(
+        self,
+        normalized: dict[str, str],
+        port: int,
+        device_type: str,
+        prod: bool,
+    ) -> dict[str, str]:
+        defaults = {
+            key: value
+            for key, value in normalized.items()
+            if (
+                key not in self._EXCLUDED_DEFAULT_VAR_COLUMNS
+                and self._var_name_pattern.match(key)
+            )
+        }
+        defaults["host"] = normalized["host"]
+        defaults["ip"] = normalized["host"]
+        defaults["port"] = str(port)
+        defaults["device_type"] = device_type
+        defaults["hostname"] = normalized.get("name") or normalized["host"]
+        defaults["prod"] = "true" if prod else "false"
+        return {key: str(value) for key, value in defaults.items()}
 
     def import_csv(
         self,
@@ -176,8 +200,15 @@ class DeviceImportService:
                 for cmd in (normalized.get("verify_cmds") or "").split(";")
                 if cmd.strip()
             ]
+            prod = (normalized.get("prod") or "").strip().lower() == "true"
+            device_type = self._normalize_device_type(normalized["device_type"])
+            host_vars = self._default_host_vars(
+                normalized=normalized,
+                port=port,
+                device_type=device_type,
+                prod=prod,
+            )
             host_vars_raw = normalized.get("host_vars") or ""
-            host_vars: dict[str, str] = {}
             if host_vars_raw:
                 try:
                     loaded = json.loads(host_vars_raw)
@@ -216,8 +247,9 @@ class DeviceImportService:
                         )
                     )
                     continue
-                host_vars = {str(key): str(value) for key, value in loaded.items()}
-            prod = (normalized.get("prod") or "").strip().lower() == "true"
+                host_vars.update(
+                    {str(key): str(value) for key, value in loaded.items()}
+                )
             parsed_entries.append(
                 (
                     row_number,
@@ -225,9 +257,7 @@ class DeviceImportService:
                     DeviceProfile(
                         host=normalized["host"],
                         port=port,
-                        device_type=self._normalize_device_type(
-                            normalized["device_type"]
-                        ),
+                        device_type=device_type,
                         username=normalized["username"],
                         password=normalized["password"],
                         name=normalized.get("name") or None,

--- a/backend_v2/tests/unit/test_api_main.py
+++ b/backend_v2/tests/unit/test_api_main.py
@@ -326,11 +326,12 @@ def test_run_fails_preflight_when_command_variable_is_missing():
         json={
             "imported_device_keys": ["10.8.0.1:22"],
             "canary": {"host": "10.8.0.1", "port": 22},
-            "commands": ["hostname {{hostname}}"],
+            "commands": ["hostname {{missing_hostname}}"],
         },
     )
     assert run_response.status_code == 400
     assert "Missing command variables" in run_response.json()["detail"]
+    assert "missing_hostname" in run_response.json()["detail"]
 
 
 def test_run_prefers_host_vars_over_global_vars():

--- a/backend_v2/tests/unit/test_device_import_service.py
+++ b/backend_v2/tests/unit/test_device_import_service.py
@@ -60,7 +60,18 @@ def test_import_csv_parses_and_stores_valid_devices():
     device = result.devices[0]
     assert device.host == "10.0.0.1"
     assert device.verify_cmds == ["show run", "show ip int br"]
-    assert device.host_vars == {"hostname": "edge-1", "site": "100"}
+    assert device.host_vars == {
+        "host": "10.0.0.1",
+        "ip": "10.0.0.1",
+        "port": "22",
+        "device_type": "cisco_ios",
+        "username": "admin",
+        "name": "edge-1",
+        "hostname": "edge-1",
+        "prod": "true",
+        "site": "100",
+    }
+    assert "password" not in device.host_vars
     assert device.prod is True
     assert device.connection_ok is True
     assert result.failed_rows == []
@@ -94,6 +105,48 @@ def test_import_csv_normalizes_generic_linux_device_type():
 
     assert len(result.devices) == 1
     assert result.devices[0].device_type == "linux"
+    assert result.devices[0].host_vars["device_type"] == "linux"
+
+
+def test_import_csv_adds_default_host_vars_from_csv_columns():
+    service = DeviceImportService(
+        store=InMemoryDeviceStore(),
+        validator=SimulatedConnectionValidator(),
+    )
+    result = service.import_csv(
+        "host,port,device_type,username,password,name,site,bad-key\n"
+        "10.0.8.1,2222,cisco_ios,admin,secret,edge-8,tokyo,ignored\n"
+    )
+
+    assert len(result.devices) == 1
+    assert result.devices[0].host_vars == {
+        "host": "10.0.8.1",
+        "ip": "10.0.8.1",
+        "port": "2222",
+        "device_type": "cisco_ios",
+        "username": "admin",
+        "name": "edge-8",
+        "hostname": "edge-8",
+        "prod": "false",
+        "site": "tokyo",
+    }
+
+
+def test_import_csv_explicit_host_vars_override_default_host_vars():
+    service = DeviceImportService(
+        store=InMemoryDeviceStore(),
+        validator=SimulatedConnectionValidator(),
+    )
+    result = service.import_csv(
+        "host,port,device_type,username,password,name,host_vars\n"
+        "10.0.8.2,22,cisco_ios,admin,pass,display-name,"
+        '"{""hostname"":""edge-8-2"",""ip"":""192.0.2.8""}"\n'
+    )
+
+    assert len(result.devices) == 1
+    assert result.devices[0].host_vars["hostname"] == "edge-8-2"
+    assert result.devices[0].host_vars["ip"] == "192.0.2.8"
+    assert result.devices[0].host_vars["host"] == "10.0.8.2"
 
 
 def test_import_csv_collects_failed_rows():

--- a/docs/SPECIFICATION.ja.md
+++ b/docs/SPECIFICATION.ja.md
@@ -63,6 +63,9 @@ host,port,device_type,username,password,name,verify_cmds,host_vars,prod
 - コマンドのプレースホルダ記法は `{{var}}`。
 - グローバル変数はジョブ作成時（`POST /api/v2/jobs` の `global_vars`）に指定。
 - ホスト毎変数は CSV の `host_vars` 列で指定。
+- インポートされた CSV 列も、列名が有効な変数名であればデフォルトのホスト毎変数として利用可能。
+  組み込み変数は `host`, `ip`, `hostname`, `port`, `device_type`, `name`,
+  `username`, `prod`。`password`, `host_vars`, `verify_cmds` は対象外。
 - マージ優先順位は `host_vars > global_vars`。
 - 未解決プレースホルダが1つでもある場合、デバイス実行前に preflight で `HTTP 400` を返す。
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -63,6 +63,10 @@ host,port,device_type,username,password,name,verify_cmds,host_vars,prod
 - Command placeholders use `{{var}}` syntax.
 - Global variables are provided at job creation (`POST /api/v2/jobs` with `global_vars`).
 - Host variables are provided per imported device via CSV `host_vars`.
+- Imported CSV columns are also available as default host variables when their column
+  names are valid variable identifiers. Built-ins include `host`, `ip`, `hostname`,
+  `port`, `device_type`, `name`, `username`, and `prod`; `password`, `host_vars`,
+  and `verify_cmds` are excluded.
 - Merge precedence is `host_vars > global_vars`.
 - If any placeholder is unresolved, run preflight fails with `HTTP 400` before device execution.
 


### PR DESCRIPTION
## Summary
- Add default per-host command variables from imported CSV columns.
- Provide built-in variables for host, ip, hostname, port, device_type, name, username, and prod while excluding password, host_vars, and verify_cmds.
- Document the default variables in README and specification docs.

## Rationale
Operators can now use imported device fields directly in command templates without manually duplicating them in host_vars. Explicit host_vars still override default values.

## Tests and validation
- `python3.12 -m pytest backend_v2/tests/unit/test_device_import_service.py backend_v2/tests/unit/test_command_template.py`
- `make check`
- `git diff --check`

## Docs updated
- `README.md`
- `README.ja.md`
- `docs/SPECIFICATION.md`
- `docs/SPECIFICATION.ja.md`

## LLM involvement
Files created/modified by LLM assistance:
- `backend_v2/app/application/device_import_service.py`
- `backend_v2/tests/unit/test_device_import_service.py`
- `backend_v2/tests/unit/test_api_main.py`
- `README.md`
- `README.ja.md`
- `docs/SPECIFICATION.md`
- `docs/SPECIFICATION.ja.md`

Human review note: Codex reviewed the staged diff and ran the validation commands listed above before opening this PR.

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: 10/10 (command: `make check`)
- [x] Tests passing locally (command: `make check`)
- [x] Static analysis/type checks passing (command: `make check`)
- [x] Formatting applied (command: `make check`)
- [x] Pre-commit hooks passing
- [ ] CI green or expected to pass
- [x] No merge conflicts with base branch
- [x] Documentation updated (README, docs/, examples)
- [x] Changelog/version updated if applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description