### PR TITLE
[codex] Detect FortiOS unknown action errors

### DIFF
--- a/backend_v2/app/infrastructure/netmiko_executor.py
+++ b/backend_v2/app/infrastructure/netmiko_executor.py
@@ -37,6 +37,7 @@ ERROR_PATTERNS = [
     "Error:",
     "Ambiguous command",
     "Incomplete command",
+    "Unknown action",
 ]
 
 MAX_LOG_SIZE = 1024 * 1024
@@ -155,12 +156,17 @@ def run_status_commands(device_params: dict[str, Any], commands: str) -> str:
         outputs = []
         for cmd in command_list:
             output = connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
+            error_message = _check_for_errors(output)
+            if error_message:
+                raise RuntimeError(error_message)
             outputs.append(f"$ {cmd}\n{output}")
         return "\n\n".join(outputs)
     except NetmikoAuthenticationException as exc:
         raise RuntimeError(f"Authentication failed: {str(exc)}") from exc
     except NetmikoTimeoutException as exc:
         raise RuntimeError(f"Command execution timeout: {str(exc)}") from exc
+    except RuntimeError:
+        raise
     except Exception as exc:
         raise RuntimeError(f"SSH execution error: {str(exc)}") from exc
     finally:
@@ -313,9 +319,16 @@ def execute_device_commands(
                     connection.disconnect()
                     return result
                 add_log(f"  > {cmd}")
-                pre_outputs.append(
-                    connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
-                )
+                output = connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
+                pre_outputs.append(output)
+                error_message = _check_for_errors(output)
+                if error_message:
+                    connection.disconnect()
+                    return handle_failure(
+                        error_code="command_error",
+                        error_message=error_message,
+                        log_message=f"ERROR: {error_message}",
+                    )
             result["pre_output"] = "\n".join(pre_outputs)
             add_log("Pre-verification complete")
 
@@ -358,9 +371,16 @@ def execute_device_commands(
                     connection.disconnect()
                     return result
                 add_log(f"  > {cmd}")
-                post_outputs.append(
-                    connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
-                )
+                output = connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
+                post_outputs.append(output)
+                error_message = _check_for_errors(output)
+                if error_message:
+                    connection.disconnect()
+                    return handle_failure(
+                        error_code="command_error",
+                        error_message=error_message,
+                        log_message=f"ERROR: {error_message}",
+                    )
             result["post_output"] = "\n".join(post_outputs)
             add_log("Post-verification complete")
 

--- a/backend_v2/app/infrastructure/netmiko_executor.py
+++ b/backend_v2/app/infrastructure/netmiko_executor.py
@@ -155,7 +155,7 @@ def run_status_commands(device_params: dict[str, Any], commands: str) -> str:
         )
         outputs = []
         for cmd in command_list:
-            output = connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
+            output = str(connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT))
             error_message = _check_for_errors(output)
             if error_message:
                 raise RuntimeError(error_message)
@@ -319,7 +319,7 @@ def execute_device_commands(
                     connection.disconnect()
                     return result
                 add_log(f"  > {cmd}")
-                output = connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
+                output = str(connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT))
                 pre_outputs.append(output)
                 error_message = _check_for_errors(output)
                 if error_message:
@@ -345,8 +345,8 @@ def execute_device_commands(
         if has_timed_out(stage="configuration apply"):
             connection.disconnect()
             return result
-        apply_output = connection.send_config_set(
-            commands, read_timeout=COMMAND_TIMEOUT
+        apply_output = str(
+            connection.send_config_set(commands, read_timeout=COMMAND_TIMEOUT)
         )
         result["apply_output"] = apply_output
         add_log("Configuration applied")
@@ -371,7 +371,7 @@ def execute_device_commands(
                     connection.disconnect()
                     return result
                 add_log(f"  > {cmd}")
-                output = connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT)
+                output = str(connection.send_command(cmd, read_timeout=COMMAND_TIMEOUT))
                 post_outputs.append(output)
                 error_message = _check_for_errors(output)
                 if error_message:

--- a/backend_v2/tests/unit/test_netmiko_executor.py
+++ b/backend_v2/tests/unit/test_netmiko_executor.py
@@ -134,6 +134,46 @@ def test_execute_device_commands_detects_command_error(monkeypatch):
     assert "Command error detected" in str(result["error"])
 
 
+def test_execute_device_commands_detects_fortios_unknown_action(monkeypatch):
+    fake = _FakeConnection()
+
+    def send_config_set_error(commands: list[str], read_timeout: int) -> str:
+        del commands, read_timeout
+        return (
+            'FORTIOS # next\nUnknown action 0\n \nFORTIOS # edit "1"\nUnknown action 0'
+        )
+
+    fake.send_config_set = send_config_set_error  # type: ignore[method-assign]
+    monkeypatch.setattr(executor, "ConnectHandler", lambda **kwargs: fake)
+
+    result = executor.execute_device_commands(
+        device_params=_device_params(),
+        commands=["bad fortios command"],
+        verify_cmds=[],
+        is_canary=True,
+    )
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "command_error"
+    assert "Unknown action" in str(result["error"])
+
+
+def test_run_status_commands_detects_fortios_unknown_action(monkeypatch):
+    fake = _FakeConnection(
+        pre_output='FORTIOS # next\nUnknown action 0\n \nFORTIOS # edit "1"\nUnknown action 0'
+    )
+    monkeypatch.setattr(executor, "ConnectHandler", lambda **kwargs: fake)
+
+    try:
+        executor.run_status_commands(_device_params(), "bad fortios command")
+    except RuntimeError as exc:
+        assert "Unknown action" in str(exc)
+    else:
+        raise AssertionError("FortiOS Unknown action output should fail")
+
+    assert fake.disconnected is True
+
+
 def test_execute_device_commands_cancelled_before_connect(monkeypatch):
     cancel_event = threading.Event()
     cancel_event.set()


### PR DESCRIPTION
## Summary
- Treat FortiOS `Unknown action` output as a command execution failure.
- Apply command-output error detection to status commands and pre/post verification commands, not only config apply output.
- Add unit coverage using FortiOS-style prompt output from the reported logs.

## Rationale
FortiOS may return `Unknown action 0` for nonexistent commands or invalid command context without Netmiko raising an exception. The executor now normalizes that device output into `command_error` so failed commands are not reported as successful.

## Validation
- `PYTHONPATH=. python3 -m pytest backend_v2/tests/unit/test_netmiko_executor.py -v`
- `python3 -m black backend_v2/tests/unit/test_netmiko_executor.py`
- `PYTHON=python3 ./scripts/run_v2_checks.sh`

## LLM involvement
Files created/modified with LLM assistance:
- `backend_v2/app/infrastructure/netmiko_executor.py`
- `backend_v2/tests/unit/test_netmiko_executor.py`

Human review performed: diff reviewed locally; repository linting, formatting checks, static analysis, pre-commit hooks, py_compile, and unit tests passed via `./scripts/run_v2_checks.sh`.

## PR checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: 10/10 (command: `PYTHON=python3 ./scripts/run_v2_checks.sh`)
- [x] Tests passing locally (command: `PYTHON=python3 ./scripts/run_v2_checks.sh`)
- [x] Static analysis/type checks passing (command: `PYTHON=python3 ./scripts/run_v2_checks.sh`)
- [x] Formatting applied (command: `python3 -m black backend_v2/tests/unit/test_netmiko_executor.py`)
- [x] Pre-commit hooks passing
- [ ] CI green or expected to pass
- [x] No merge conflicts with base branch
- [x] Documentation updated (README, docs/, examples) — not applicable; behavior is internal error normalization
- [x] Changelog/version updated if applicable — not applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description