### PR TITLE
[codex] Keep verify scope selectable

### DIFF
--- a/frontend_v2/public/app.js
+++ b/frontend_v2/public/app.js
@@ -260,12 +260,12 @@ function describeVerifyPlan(verifyMode, verifyCommands) {
 function updateVerifyModeControls() {
   const hasVerifyCommands = parseCommands(verifyCommandsEl.value).length > 0;
   verifyModeEls.forEach((el) => {
-    el.disabled = !hasVerifyCommands;
+    el.disabled = false;
   });
   if (verifyModeHintEl) {
     verifyModeHintEl.textContent = hasVerifyCommands
       ? "Choose where verify commands run after the canary step."
-      : "No verify commands configured. This setting will be ignored.";
+      : "No verify commands configured. You can still choose the canary rollout scope.";
   }
 }
 


### PR DESCRIPTION
## Summary
- Keep the `Verify commands apply to` radio options selectable even when no verify commands are configured.
- Update the empty-state hint to clarify that canary rollout scope can still be chosen.

## Rationale
The canary selection describes how the actual deployment commands roll out, not only where verification commands run. Disabling the selection when verify commands are empty prevented users from choosing the intended canary rollout scope.

## LLM involvement
- Files modified with LLM assistance: `frontend_v2/public/app.js`
- Human review required for correctness, security, and licensing.

## Validation
- `make check`
- `git diff --check`

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: project checks passed (command: `make check`)
- [x] Tests passing locally (command: `make check`)
- [x] Static analysis/type checks passing (command: `make check`)
- [x] Formatting applied (command: `make check`)
- [x] Pre-commit hooks passing
- [ ] CI green or expected to pass
- [ ] No merge conflicts with base branch
- [ ] Documentation updated (README, docs/, examples)
- [ ] Changelog/version updated if applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description
