### PR TITLE
[codex] Fix command stream scroll retention

### DIFF
--- a/frontend_v2/public/app.js
+++ b/frontend_v2/public/app.js
@@ -933,7 +933,7 @@ function buildDeviceCardsHtml(source, deviceNameMap = {}) {
           <h4>${escapeHtml(`${key} (${hostname})`)} ${isCanary ? '<span class="status-badge status-paused">CANARY</span>' : ""} <span class="status-badge status-${status}">${statusLabel(status)}</span></h4>
           <div class="meta">Attempts: ${attempts || "-"} ${error ? `/ Error: ${escapeHtml(error)}` : ""}</div>
           <div class="output-label">Command Stream</div>
-          <pre class="stream-output">${escapeHtml(streamText)}</pre>
+          <pre class="stream-output" data-device-key="${escapeHtml(key)}">${escapeHtml(streamText)}</pre>
           ${result?.pre_output ? `<div class="output-label">Verify Pre</div><pre class="verify-output">${escapeHtml(result.pre_output)}</pre>` : ""}
           ${result?.apply_output ? `<div class="output-label">Apply Output</div><pre class="verify-output">${escapeHtml(result.apply_output)}</pre>` : ""}
           ${result?.post_output ? `<div class="output-label">Verify Post</div><pre class="verify-output">${escapeHtml(result.post_output)}</pre>` : ""}
@@ -945,9 +945,38 @@ function buildDeviceCardsHtml(source, deviceNameMap = {}) {
     .join("");
 }
 
+function snapshotStreamScrollState(devicesEl) {
+  const scrollState = {};
+  devicesEl.querySelectorAll(".stream-output[data-device-key]").forEach((el) => {
+    const deviceKey = el.getAttribute("data-device-key");
+    if (!deviceKey) {
+      return;
+    }
+    scrollState[deviceKey] = {
+      scrollTop: el.scrollTop,
+      pinnedToBottom: el.scrollTop + el.clientHeight >= el.scrollHeight - 4,
+    };
+  });
+  return scrollState;
+}
+
+function restoreStreamScrollState(devicesEl, scrollState) {
+  devicesEl.querySelectorAll(".stream-output[data-device-key]").forEach((el) => {
+    const deviceKey = el.getAttribute("data-device-key");
+    const state = deviceKey ? scrollState[deviceKey] : null;
+    if (!state) {
+      el.scrollTop = el.scrollHeight;
+      return;
+    }
+    el.scrollTop = state.pinnedToBottom ? el.scrollHeight : state.scrollTop;
+  });
+}
+
 function renderExecutionPanel(summaryEl, devicesEl, source, eventCount = 0, deviceNameMap = {}) {
+  const streamScrollState = snapshotStreamScrollState(devicesEl);
   summaryEl.innerHTML = buildExecutionSummaryHtml(source, eventCount);
   devicesEl.innerHTML = buildDeviceCardsHtml(source, deviceNameMap);
+  restoreStreamScrollState(devicesEl, streamScrollState);
 }
 
 function renderMonitorState() {


### PR DESCRIPTION
## Summary
- Preserve per-device Command Stream scroll positions across monitor re-renders.
- Keep streams pinned to the bottom only when the user was already at the bottom.

## Rationale
The monitor panel rebuilt device cards with `innerHTML` on every stream event. That replaced each Command Stream `<pre>` element and reset the browser scroll state, so user scrollbar interaction could jump back or become difficult while other hosts were updating.

## Validation
- `node --check frontend_v2/public/app.js`
- `make check`
- Opened `http://127.0.0.1:8765/` in the in-app browser and confirmed no console errors.

## Documentation
- No README/docs/changelog update. This is a narrow UI bug fix with no user-facing API or workflow change.

## LLM Involvement
- Modified with assistance from an AI (Large Language Model): `frontend_v2/public/app.js`
- Human review still required for correctness, security, and licensing.

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: maximum configured checks passing (command: `make check`)
- [x] Tests passing locally (command: `make check`)
- [x] Static analysis/type checks passing (command: `make check`)
- [x] Formatting applied (command: `make check`)
- [x] Pre-commit hooks passing
- [ ] CI green or expected to pass
- [x] No merge conflicts with base branch
- [x] Documentation updated or not applicable
- [x] Changelog/version updated or not applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description