### PR TITLE
[codex] Cache bust frontend app script

### DIFF
--- a/backend_v2/app/frontend_server.py
+++ b/backend_v2/app/frontend_server.py
@@ -46,6 +46,7 @@ CSP_POLICY: Final[str] = (
     "frame-ancestors 'none'; "
     "form-action 'self'"
 )
+INDEX_CACHE_CONTROL: Final[str] = "no-cache"
 
 mimetypes.add_type("application/javascript", ".js")
 
@@ -100,6 +101,8 @@ class HardenedStaticHandler(SimpleHTTPRequestHandler):
 
     def end_headers(self) -> None:
         self.send_header("Content-Security-Policy", CSP_POLICY)
+        if unquote(urlsplit(self.path).path) in {"", "/", "/index.html"}:
+            self.send_header("Cache-Control", INDEX_CACHE_CONTROL)
         self.send_header("X-Content-Type-Options", "nosniff")
         self.send_header("Referrer-Policy", "no-referrer")
         self.send_header("X-Frame-Options", "DENY")

--- a/backend_v2/tests/unit/test_frontend_server.py
+++ b/backend_v2/tests/unit/test_frontend_server.py
@@ -58,6 +58,7 @@ def test_root_path_serves_index_with_security_headers(tmp_path: Path):
                 "default-src 'self'"
             )
             assert response.headers["X-Content-Type-Options"] == "nosniff"
+            assert response.headers["Cache-Control"] == "no-cache"
             assert response.headers["Referrer-Policy"] == "no-referrer"
             assert response.headers["X-Frame-Options"] == "DENY"
             assert response.headers["Cross-Origin-Opener-Policy"] == "same-origin"
@@ -80,6 +81,15 @@ def test_repo_frontend_index_includes_locale_selector():
 
     assert 'id="localeSelect"' in body
     assert 'data-i18n-text="locale.label"' in body
+
+
+def test_repo_frontend_index_versions_app_script():
+    repo_root = Path(__file__).resolve().parents[3]
+    index_path = repo_root / "frontend_v2" / "public" / "index.html"
+    body = index_path.read_text(encoding="utf-8")
+
+    assert 'src="./app.js?v=' in body
+    assert "Bump this query version whenever app.js changes" in body
 
 
 def test_unknown_paths_return_404(tmp_path: Path):

--- a/docs/CODING-AGENT-GUIDE.md
+++ b/docs/CODING-AGENT-GUIDE.md
@@ -154,6 +154,10 @@ Start with:
 - `frontend_v2/public/api-client.js`: API contracts consumed by the UI
 - `backend_v2/app/frontend_server.py`: hardened static serving behavior
 
+When changing `frontend_v2/public/app.js`, also bump the `?v=` query version on the
+`./app.js` script tag in `frontend_v2/public/index.html`. The frontend has no build
+step, so this explicit version is the cache-busting mechanism for browser clients.
+
 Update tests in:
 
 - `backend_v2/tests/unit/test_frontend_server.py` for static server changes

--- a/frontend_v2/public/index.html
+++ b/frontend_v2/public/index.html
@@ -1180,6 +1180,7 @@ show ip interface brief</textarea>
     </section>
   </div>
 
-  <script type="module" src="./app.js"></script>
+  <!-- Bump this query version whenever app.js changes so browsers fetch the latest UI code. -->
+  <script type="module" src="./app.js?v=2026-05-21-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-cache` for `index.html` responses from the hardened frontend static server.
- Add an explicit `?v=` cache-busting query to the `app.js` module script.
- Document the required cache-busting version bump for future coding-agent changes to `app.js`.
- Add frontend server tests covering the cache header and versioned app script reference.

## Rationale
Browsers can keep using a stale `app.js` when the module URL remains unchanged. Because this frontend currently has no build step or hashed asset pipeline, an explicit query version on `app.js` gives clients a changed URL after frontend updates while `index.html` is revalidated on each load.

## Validation
- `PYTHONPATH=. pytest backend_v2/tests/unit/test_frontend_server.py`
- `make check`

## LLM involvement
Files created/modified with LLM assistance:
- `backend_v2/app/frontend_server.py`
- `backend_v2/tests/unit/test_frontend_server.py`
- `docs/CODING-AGENT-GUIDE.md`
- `frontend_v2/public/index.html`

Human review required for correctness, security, and licensing.

## PR Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed - score: 10/10 (command: `make check`)
- [x] Tests passing locally (command: `make check`)
- [x] Static analysis/type checks passing (command: `make check`)
- [x] Formatting applied (command: `make check`)
- [x] Pre-commit hooks passing (command: `make check`)
- [ ] CI green or expected to pass
- [ ] No merge conflicts with base branch
- [x] Documentation updated (README, docs/, examples)
- [ ] Changelog/version updated if applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description
