### PR TITLE
fix(frontend): remove inline Japanese UI copy

### DIFF
--- a/backend_v2/tests/unit/test_frontend_server.py
+++ b/backend_v2/tests/unit/test_frontend_server.py
@@ -82,6 +82,16 @@ def test_repo_frontend_index_includes_locale_selector():
     assert 'data-i18n-text="locale.label"' in body
 
 
+def test_repo_frontend_index_has_no_inline_japanese_ui_copy():
+    repo_root = Path(__file__).resolve().parents[3]
+    index_path = repo_root / "frontend_v2" / "public" / "index.html"
+    body = index_path.read_text(encoding="utf-8")
+
+    assert not any(
+        "\u3040" <= char <= "\u30ff" or "\u4e00" <= char <= "\u9fff" for char in body
+    )
+
+
 def test_unknown_paths_return_404(tmp_path: Path):
     (tmp_path / "index.html").write_text("ok", encoding="utf-8")
 

--- a/frontend_v2/public/app.js
+++ b/frontend_v2/public/app.js
@@ -131,6 +131,12 @@ const translations = {
         help: "Open command variable usage examples for global and host vars.",
       },
     },
+    commandCards: {
+      applyTitle: "Commands sent to devices",
+      applyCopy: "These commands change target device configuration and run in order, one line at a time.",
+      verifyTitle: "Verification commands",
+      verifyCopy: "Use these commands to check state before and after changes. This field can be blank.",
+    },
     labels: {
       prodWarning: "Production Environment",
       importedDevices: "imported devices: {count}",

--- a/frontend_v2/public/index.html
+++ b/frontend_v2/public/index.html
@@ -1024,9 +1024,9 @@ You may obtain a copy of the License at
             <div>
               <h3 id="applyCommandsTitle" class="command-card-title">
                 <span class="command-badge">Apply</span>
-                <span>実機へ投入するコマンド</span>
+                <span data-i18n-text="commandCards.applyTitle">Commands sent to devices</span>
               </h3>
-              <p class="command-card-copy">対象機器の設定変更に使うコマンドです。1行ごとに順番に投入されます。</p>
+              <p class="command-card-copy" data-i18n-text="commandCards.applyCopy">These commands change target device configuration and run in order, one line at a time.</p>
             </div>
           </div>
           <div>
@@ -1040,9 +1040,9 @@ show ip interface brief</textarea>
             <div>
               <h3 id="verifyCommandsTitle" class="command-card-title">
                 <span class="command-badge">Verify</span>
-                <span>確認用コマンド</span>
+                <span data-i18n-text="commandCards.verifyTitle">Verification commands</span>
               </h3>
-              <p class="command-card-copy">投入前後の状態確認に使います。空欄でも実行できます。</p>
+              <p class="command-card-copy" data-i18n-text="commandCards.verifyCopy">Use these commands to check state before and after changes. This field can be blank.</p>
             </div>
           </div>
           <div class="verify-controls">


### PR DESCRIPTION
## Summary

Remove inline Japanese UI copy that remained in the frontend command cards after the localization foundation was merged.

This change:
- replaces the Apply / Verify card titles and descriptions with English text
- wires those strings through existing `data-i18n-text` keys
- adds English dictionary entries in `translations.en`
- adds a lightweight regression test to catch inline Japanese UI copy in `frontend_v2/public/index.html`

## Tests

Validated with:
- `rg -n "[ぁ-んァ-ヶ一-龠]" frontend_v2/public backend_v2/tests/unit/test_frontend_server.py`
- `node --check frontend_v2/public/app.js`
- `python3 -m pytest backend_v2/tests/unit/test_frontend_server.py -q`
- `make check`

## LLM Involvement

Files modified with LLM assistance:
- `frontend_v2/public/index.html`
- `frontend_v2/public/app.js`
- `backend_v2/tests/unit/test_frontend_server.py`
