### PR TITLE
[codex] Split command and verify scopes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -110,10 +110,12 @@ make check-integration
   - 実行コマンド
   - 確認用コマンド
   - 実行設定（有効な同時実行数を含む）
+- `Execution commands apply to` で、実行コマンドを canary 成功後に全選択対象へ投入するか、
+  canary デバイスのみに投入するかを選択します。
 - `Canary success after` はラジオ選択です。
   - `Parallel`: 入力した `concurrency_limit` を使用
   - `Sequential (1 device at a time)`: `concurrency_limit=1` を強制し、入力欄は無効化されます
-- バックエンドAPIの変更はなく、方式の差分はフロントエンドで `concurrency_limit` に反映します。
+- 実行範囲が `Canary device only` の場合、post-canary strategy は適用されません。
 
 ## アプリ状態初期化（v2）
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ make check-integration
   - run commands
   - verify commands
   - effective run settings
+- `Execution commands apply to` controls whether execution commands run on all selected targets
+  after the canary succeeds or only on the canary device.
 - `Canary success after` controls post-canary fanout:
   - `Parallel` uses input `concurrency_limit`
   - `Sequential (1 device at a time)` forces `concurrency_limit=1` and disables the input
-- No backend API changes were added; strategy is mapped only to `concurrency_limit`.
+- Post-canary strategy is ignored when execution scope is `Canary device only`.
 
 ## App state reset (v2)
 

--- a/backend_v2/app/api/main.py
+++ b/backend_v2/app/api/main.py
@@ -251,6 +251,15 @@ def _prepare_run(job_id: str, payload: RunJobRequest) -> tuple[
         raise HTTPException(status_code=404, detail="Job not found")
 
     devices, canary = _resolve_run_targets(payload)
+    command_scope = (payload.command_scope or "all").strip().lower()
+    if command_scope not in {"all", "canary"}:
+        raise HTTPException(
+            status_code=400,
+            detail="command_scope must be one of: all, canary",
+        )
+    if command_scope == "canary":
+        devices = [device for device in devices if device.key == canary.key]
+
     verify_mode = (payload.verify_mode or "all").strip().lower()
     if verify_mode not in {"all", "canary", "none"}:
         raise HTTPException(

--- a/backend_v2/app/api/schemas.py
+++ b/backend_v2/app/api/schemas.py
@@ -57,6 +57,7 @@ class RunJobRequest(BaseModel):
 
     canary: Optional[DeviceTargetPayload] = None
     commands: List[str] = Field(min_length=1)
+    command_scope: str = Field(default="all")
     verify_commands: Optional[List[str]] = None
     verify_mode: str = Field(default="all")
     imported_device_keys: Optional[List[str]] = None

--- a/backend_v2/tests/unit/test_api_main.py
+++ b/backend_v2/tests/unit/test_api_main.py
@@ -913,6 +913,80 @@ def test_run_with_imported_device_keys_limits_targets():
     assert list(payload["device_results"].keys()) == ["10.5.0.2:22"]
 
 
+def test_run_command_scope_canary_targets_only_canary(monkeypatch):
+    client = TestClient(app)
+    imported = client.post(
+        "/api/v2/devices/import",
+        content=(
+            "host,port,device_type,username,password,name,verify_cmds,host_vars\n"
+            "10.15.0.1,22,cisco_ios,admin,pass,edge-a,show run,\n"
+            "10.15.0.2,22,cisco_ios,admin,pass,edge-b,show run,\n"
+        ),
+        headers={"Content-Type": "text/plain"},
+    )
+    assert imported.status_code == 200
+    created = client.post(
+        "/api/v2/jobs",
+        json={"job_name": "command-scope-canary", "creator": "tester"},
+    )
+    assert created.status_code == 200
+    job_id = created.json()["job_id"]
+    captured: dict[str, object] = {}
+
+    def fake_run_job(**kwargs):
+        captured.update(kwargs)
+        return JobRunSummary(
+            job_id=job_id,
+            status=JobStatus.COMPLETED,
+            commands=["show version"],
+            verify_commands=[],
+            target_device_keys=[device.key for device in kwargs["devices"]],
+            device_results={
+                "10.15.0.2:22": DeviceExecutionResult(status="success"),
+            },
+        )
+
+    monkeypatch.setattr(api_main.engine, "run_job", fake_run_job)
+    run = client.post(
+        f"/api/v2/jobs/{job_id}/run",
+        json={
+            "commands": ["show version"],
+            "command_scope": "canary",
+            "imported_device_keys": ["10.15.0.1:22", "10.15.0.2:22"],
+            "canary": {"host": "10.15.0.2", "port": 22},
+        },
+    )
+    assert run.status_code == 200
+    assert [device.key for device in captured["devices"]] == ["10.15.0.2:22"]
+    assert list(captured["commands_by_device"].keys()) == ["10.15.0.2:22"]
+    assert run.json()["target_device_keys"] == ["10.15.0.2:22"]
+
+
+def test_run_rejects_invalid_command_scope():
+    client = TestClient(app)
+    import_devices_for_run(
+        client,
+        ["10.17.0.1,22,cisco_ios,admin,pass,edge-a,show run,"],
+    )
+    create = client.post(
+        "/api/v2/jobs", json={"job_name": "invalid-command-scope", "creator": "tester"}
+    )
+    assert create.status_code == 200
+    job_id = create.json()["job_id"]
+
+    run = client.post(
+        f"/api/v2/jobs/{job_id}/run",
+        json={
+            "commands": ["show version"],
+            "command_scope": "none",
+            "imported_device_keys": ["10.17.0.1:22"],
+            "canary": {"host": "10.17.0.1", "port": 22},
+        },
+    )
+    assert run.status_code == 400
+    assert run.json()["detail"] == "command_scope must be one of: all, canary"
+
+
 def test_run_rejects_empty_imported_device_keys():
     client = TestClient(app)
     create = client.post(

--- a/docs/SPECIFICATION.ja.md
+++ b/docs/SPECIFICATION.ja.md
@@ -101,6 +101,13 @@ host,port,device_type,username,password,name,verify_cmds,host_vars,prod
 ## 実行リクエスト拡張
 
 - `verify_commands`（任意）: 指定時は全対象デバイスへ共通適用。
+- `command_scope`（任意、デフォルト `all`）: 実行コマンドの適用範囲。
+  - `all`: canary を先に実行し、成功後に残りの選択対象へ投入。
+  - `canary`: canary デバイスのみに実行コマンドを投入。
+- `verify_mode`（任意、デフォルト `all`）: 確認用コマンドの適用範囲。
+  - `all`: 実行対象になった全デバイスで確認用コマンドを実行。
+  - `canary`: canary デバイスのみで確認用コマンドを実行。
+  - `none`: 確認用コマンドをスキップ。
 - `canary`（必須）: canary対象デバイス（`host`, `port`）を明示指定。
 - `imported_device_keys`（必須）: import済みデバイスの実行対象を `host:port` で明示。
   - 空配列は `HTTP 400`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -102,6 +102,13 @@ host,port,device_type,username,password,name,verify_cmds,host_vars,prod
 ## Run request extensions
 
 - `verify_commands` (optional): if provided, used for all target devices.
+- `command_scope` (optional, default `all`): execution command scope.
+  - `all`: run the canary first, then run remaining selected targets after canary success.
+  - `canary`: run execution commands only on the canary device.
+- `verify_mode` (optional, default `all`): verify command scope.
+  - `all`: run verify commands on every executed device.
+  - `canary`: run verify commands only on the canary device.
+  - `none`: skip verify commands.
 - `canary` (required): explicit canary target (`host`, `port`).
 - `imported_device_keys` (required): explicit imported-device targets (`host:port` list).
   - empty list is rejected with `HTTP 400`

--- a/frontend_v2/public/api-client.js
+++ b/frontend_v2/public/api-client.js
@@ -167,12 +167,13 @@ export class NwEditApiClient {
   /**
    * @param {string} jobId
    * @param {string[]} commands
-   * @param {{ verifyCommands?: string[], verifyMode?: string, importedDeviceKeys?: string[], canary?: DeviceTarget, concurrencyLimit?: number, staggerDelay?: number, stopOnError?: boolean }=} options
+   * @param {{ commandScope?: string, verifyCommands?: string[], verifyMode?: string, importedDeviceKeys?: string[], canary?: DeviceTarget, concurrencyLimit?: number, staggerDelay?: number, stopOnError?: boolean }=} options
    * @returns {Promise<RunJobResponse>}
    */
   async runJob(jobId, commands, options = {}) {
     const payload = {
       commands,
+      command_scope: options.commandScope || "all",
       verify_commands: options.verifyCommands,
       verify_mode: options.verifyMode || "all",
       concurrency_limit: options.concurrencyLimit ?? 5,
@@ -193,12 +194,13 @@ export class NwEditApiClient {
   /**
    * @param {string} jobId
    * @param {string[]} commands
-   * @param {{ verifyCommands?: string[], verifyMode?: string, importedDeviceKeys?: string[], canary?: DeviceTarget, concurrencyLimit?: number, staggerDelay?: number, stopOnError?: boolean }=} options
+   * @param {{ commandScope?: string, verifyCommands?: string[], verifyMode?: string, importedDeviceKeys?: string[], canary?: DeviceTarget, concurrencyLimit?: number, staggerDelay?: number, stopOnError?: boolean }=} options
    * @returns {Promise<JobSummary>}
    */
   async runJobAsync(jobId, commands, options = {}) {
     const payload = {
       commands,
+      command_scope: options.commandScope || "all",
       verify_commands: options.verifyCommands,
       verify_mode: options.verifyMode || "all",
       concurrency_limit: options.concurrencyLimit ?? 5,

--- a/frontend_v2/public/app.js
+++ b/frontend_v2/public/app.js
@@ -58,6 +58,9 @@ const selectAllImportedBtn = document.getElementById("selectAllImportedBtn");
 const clearImportedSelectionBtn = document.getElementById("clearImportedSelectionBtn");
 const verifyCommandsEl = document.getElementById("verifyCommands");
 const verifyModeHintEl = document.getElementById("verifyModeHint");
+const commandScopeEls = Array.from(
+  document.querySelectorAll('input[name="commandScope"]')
+);
 const verifyModeEls = Array.from(
   document.querySelectorAll('input[name="verifyMode"]')
 );
@@ -170,8 +173,8 @@ const translations = {
       selectedJob: "selected: {jobId} ({status}) events={events}",
     },
     messages: {
-      verifyChoose: "Choose where verify commands run after the canary step.",
-      verifyIgnored: "No verify commands configured. You can still choose the canary rollout scope.",
+      verifyChoose: "Choose where configured verify commands run.",
+      verifyIgnored: "No verify commands configured. Execution command scope still applies.",
       validatingDevices: "Validating devices... {processed}/{total}",
       csvImportFailed: "CSV import failed",
       globalVarsParseError: "global vars JSON parse error: {error}",
@@ -195,16 +198,20 @@ const translations = {
       concurrencyLimitInvalid: "concurrency_limit must be >= 1",
       staggerDelayInvalid: "stagger_delay must be >= 0",
       postCanaryStrategyInvalid: "postCanaryStrategy must be parallel or sequential",
+      commandScopeInvalid: "commandScope must be all or canary",
       canaryRequired: "canary device is required",
       canaryIncluded: "canary device must be included in target devices",
       executionModeAsync: "Execution mode: Async (/run/async)",
       canaryFlowSequential: "Canary -> Device-1 -> Device-2 -> ...",
       canaryFlowParallel: "Canary -> [Device-1, Device-2, ...] (parallel up to {limit})",
+      canaryFlowOnly: "Canary only",
       settingCanary: "Canary: {value}",
+      settingCommandScope: "Execution scope: {value}",
       settingVerify: "Verify: {value}",
       settingStopOnError: "Stop on error: {value}",
       settingStaggerDelay: "Stagger delay: {value}s",
       settingPostCanary: "Post-canary strategy: {value}",
+      settingNotApplicable: "not applicable",
       settingConcurrencyInput: "Concurrency input: {value}",
       settingConcurrencyDisabled: "disabled (sequential mode)",
       settingEffectiveConcurrency: "Effective concurrency: {value}",
@@ -581,6 +588,15 @@ function selectedVerifyMode() {
   return selected ? selected.value : "all";
 }
 
+function selectedCommandScope() {
+  const selected = commandScopeEls.find((el) => el.checked);
+  return selected ? selected.value : "all";
+}
+
+function describeCommandScope(scope) {
+  return scope === "canary" ? "Canary device only" : "Canary first, then all devices";
+}
+
 function describeVerifyMode(mode) {
   switch (mode) {
     case "canary":
@@ -589,7 +605,7 @@ function describeVerifyMode(mode) {
       return "Skip verify commands";
     case "all":
     default:
-      return "Canary first, then all devices";
+      return "All executed devices";
   }
 }
 
@@ -1116,7 +1132,12 @@ function resetCreateFormState() {
   globalVarsEl.value = globalVarsEl.defaultValue;
   commandsEl.value = commandsEl.defaultValue;
   verifyCommandsEl.value = verifyCommandsEl.defaultValue;
-  verifyModeEl.value = verifyModeEl.defaultValue;
+  commandScopeEls.forEach((el) => {
+    el.checked = el.defaultChecked;
+  });
+  verifyModeEls.forEach((el) => {
+    el.checked = el.defaultChecked;
+  });
   concurrencyLimitEl.value = concurrencyLimitEl.defaultValue;
   staggerDelayEl.value = staggerDelayEl.defaultValue;
   stopOnErrorEl.checked = stopOnErrorEl.defaultChecked;
@@ -1666,7 +1687,12 @@ function selectedPostCanaryStrategy() {
 
 function updatePostCanaryControls() {
   const strategy = selectedPostCanaryStrategy();
-  const isParallel = strategy === "parallel";
+  const isCanaryOnly = selectedCommandScope() === "canary";
+  const isParallel = strategy === "parallel" && !isCanaryOnly;
+  postCanaryStrategyEls.forEach((el) => {
+    el.disabled = isCanaryOnly;
+    el.setAttribute("aria-disabled", String(isCanaryOnly));
+  });
   concurrencyLimitEl.disabled = !isParallel;
   concurrencyLimitEl.setAttribute("aria-disabled", String(!isParallel));
 }
@@ -1682,6 +1708,7 @@ function collectRunInput() {
   const creator = document.getElementById("creator").value.trim();
   const globalVarsText = document.getElementById("globalVars").value;
   const commands = parseCommands(document.getElementById("commands").value);
+  const commandScope = selectedCommandScope();
   const verifyCommands = parseCommands(verifyCommandsEl.value);
   const verifyMode = selectedVerifyMode();
   const concurrencyLimit = Number(concurrencyLimitEl.value || "5");
@@ -1701,6 +1728,9 @@ function collectRunInput() {
   if (!["parallel", "sequential"].includes(postCanaryStrategy)) {
     throw new Error(t("messages.postCanaryStrategyInvalid"));
   }
+  if (!["all", "canary"].includes(commandScope)) {
+    throw new Error(t("messages.commandScopeInvalid"));
+  }
 
   const targets = resolveRunTargets();
   if (targets.targetDevices.length === 0) {
@@ -1719,13 +1749,19 @@ function collectRunInput() {
   const canary = { host: canaryHost, port: Number(canaryRawPort || "22") };
   const globalVars = parseGlobalVars(globalVarsText);
   const targetDeviceKeys = targets.importedDeviceKeys;
-  const effectiveConfig = resolveEffectiveExecutionConfig(concurrencyLimit, postCanaryStrategy);
+  const executionTargetDeviceKeys =
+    commandScope === "canary" ? [canaryKey] : targetDeviceKeys;
+  const effectiveConfig =
+    commandScope === "canary"
+      ? { strategy: postCanaryStrategy, effectiveConcurrencyLimit: 1 }
+      : resolveEffectiveExecutionConfig(concurrencyLimit, postCanaryStrategy);
 
   return {
     jobName,
     creator,
     globalVars,
     commands,
+    commandScope,
     verifyCommands,
     verifyMode,
     concurrencyLimit,
@@ -1735,6 +1771,7 @@ function collectRunInput() {
     canaryKey,
     targets,
     targetDeviceKeys,
+    executionTargetDeviceKeys,
     postCanaryStrategy,
     effectiveConcurrencyLimit: effectiveConfig.effectiveConcurrencyLimit,
   };
@@ -1754,29 +1791,40 @@ function appendListItems(el, values) {
 }
 
 function buildReviewModel(runInput) {
-  const remainingCount = Math.max(0, runInput.targetDeviceKeys.length - 1);
+  const executionDeviceKeys = runInput.executionTargetDeviceKeys || runInput.targetDeviceKeys;
+  const remainingCount = Math.max(0, executionDeviceKeys.length - 1);
   const strategyText =
-    runInput.postCanaryStrategy === "sequential"
+    runInput.commandScope === "canary"
+      ? t("messages.canaryFlowOnly")
+      : runInput.postCanaryStrategy === "sequential"
       ? t("messages.canaryFlowSequential")
       : t("messages.canaryFlowParallel", { limit: runInput.effectiveConcurrencyLimit });
   return {
     modeText: t("messages.executionModeAsync"),
-    hosts: runInput.targetDeviceKeys,
+    hosts: executionDeviceKeys,
     commands: runInput.commands,
     verifyCommands: runInput.verifyCommands.length > 0 ? runInput.verifyCommands : [t("labels.none")],
     settings: [
       t("messages.settingCanary", { value: runInput.canaryKey }),
+      t("messages.settingCommandScope", { value: describeCommandScope(runInput.commandScope) }),
       t("messages.settingVerify", { value: describeVerifyPlan(runInput.verifyMode, runInput.verifyCommands) }),
       t("messages.settingStopOnError", { value: runInput.stopOnError }),
       t("messages.settingStaggerDelay", { value: runInput.staggerDelay }),
-      t("messages.settingPostCanary", { value: runInput.postCanaryStrategy === "sequential" ? "Sequential" : "Parallel" }),
+      t("messages.settingPostCanary", {
+        value:
+          runInput.commandScope === "canary"
+            ? t("messages.settingNotApplicable")
+            : runInput.postCanaryStrategy === "sequential"
+            ? "Sequential"
+            : "Parallel",
+      }),
       t("messages.settingConcurrencyInput", {
-        value: runInput.postCanaryStrategy === "sequential"
+        value: runInput.commandScope === "canary" || runInput.postCanaryStrategy === "sequential"
           ? t("messages.settingConcurrencyDisabled")
           : runInput.concurrencyLimit,
       }),
       t("messages.settingEffectiveConcurrency", { value: runInput.effectiveConcurrencyLimit }),
-      t("messages.settingTargetDevices", { count: runInput.targetDeviceKeys.length, remaining: remainingCount }),
+      t("messages.settingTargetDevices", { count: executionDeviceKeys.length, remaining: remainingCount }),
       t("messages.settingTargetSource"),
     ],
     flowDiagram: strategyText,
@@ -1823,7 +1871,7 @@ async function executeRun(runInput) {
   try {
     const job = await client().createJob(runInput.jobName, runInput.creator, runInput.globalVars);
     selectedJobId = job.job_id;
-    beginMonitor(job, runInput.targetDeviceKeys, runInput.canaryKey);
+    beginMonitor(job, runInput.executionTargetDeviceKeys, runInput.canaryKey);
     appendLog(t("messages.jobCreated", { jobId: job.job_id }));
     openJobSocket(currentApiBase(), job.job_id);
 
@@ -1832,6 +1880,7 @@ async function executeRun(runInput) {
       runInput.commands,
       {
         verifyCommands: runInput.verifyCommands,
+        commandScope: runInput.commandScope,
         verifyMode: runInput.verifyMode,
         importedDeviceKeys: runInput.targets.importedDeviceKeys,
         canary: runInput.canary,
@@ -1903,6 +1952,9 @@ reviewToggleHostsBtn?.addEventListener("click", () => {
 });
 verifyModeEls.forEach((el) => {
   el.addEventListener("change", updateVerifyModeControls);
+});
+commandScopeEls.forEach((el) => {
+  el.addEventListener("change", updatePostCanaryControls);
 });
 postCanaryStrategyEls.forEach((el) => {
   el.addEventListener("change", updatePostCanaryControls);

--- a/frontend_v2/public/index.html
+++ b/frontend_v2/public/index.html
@@ -1034,6 +1034,19 @@ You may obtain a copy of the License at
             <textarea id="commands" placeholder="snmp-server location DC1&#10;snmp-server contact NOC">show version
 show ip interface brief</textarea>
           </div>
+          <fieldset class="radio-group command-scope-group" id="commandScopeGroup">
+            <legend>Execution commands apply to</legend>
+            <label class="radio-option">
+              <input type="radio" name="commandScope" value="all" checked />
+              <strong>Canary first, then all devices</strong>
+              <span>Run execution commands on the canary device first, then continue on remaining target devices.</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="commandScope" value="canary" />
+              <strong>Canary device only</strong>
+              <span>Run execution commands only on the canary device.</span>
+            </label>
+          </fieldset>
         </section>
         <section class="command-card verify-card" aria-labelledby="verifyCommandsTitle">
           <div class="command-card-head">
@@ -1055,13 +1068,13 @@ show ip interface brief</textarea>
                 <legend>Verify commands apply to</legend>
                 <label class="radio-option verify-mode-option">
                   <input type="radio" name="verifyMode" value="all" checked />
-                  <strong>Canary first, then all devices</strong>
-                  <span>Run verify commands on the canary device first, then continue on all target devices.</span>
+                  <strong>All executed devices</strong>
+                  <span>Run verify commands on every device that receives execution commands.</span>
                 </label>
                 <label class="radio-option verify-mode-option">
                   <input type="radio" name="verifyMode" value="canary" />
                   <strong>Canary device only</strong>
-                  <span>Run verify commands on the canary device only, then finish.</span>
+                  <span>Run verify commands only on the canary device.</span>
                 </label>
                 <label class="radio-option verify-mode-option">
                   <input type="radio" name="verifyMode" value="none" />
@@ -1069,7 +1082,7 @@ show ip interface brief</textarea>
                   <span>Do not run verify commands on any device.</span>
                 </label>
               </fieldset>
-              <p class="form-note" id="verifyModeHint">Choose where verify commands run after the canary step.</p>
+              <p class="form-note" id="verifyModeHint">Choose where configured verify commands run.</p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Add `command_scope` to separate execution command scope from verify command scope.
- Add Create-page controls for `Execution commands apply to` while keeping `Verify commands apply to` focused on verification only.
- Limit backend execution targets to the canary device when `command_scope=canary`.
- Update README and specification docs for the new request field.

## Rationale
The Canary selection is intended to control the commands applied to real devices, not just verify commands. Previously the UI made that selection look tied to verify commands and the API only used `verify_mode` for verification command distribution.

## Tests
- `PYTHONPATH=. python3.12 -m pytest backend_v2/tests/unit/test_api_main.py::test_run_command_scope_canary_targets_only_canary backend_v2/tests/unit/test_api_main.py::test_run_rejects_invalid_command_scope -q`
- `make check`
- `node --check frontend_v2/public/app.js`
- `node --check frontend_v2/public/api-client.js`
- `git diff --check`
- Local smoke test against `NW_EDIT_V2_WORKER_MODE=simulated NW_EDIT_V2_VALIDATOR_MODE=simulated ./start_v2.sh`: confirmed `command_scope=canary` returns only the canary in `target_device_keys`.

## LLM involvement
- Files modified with LLM assistance: `README.ja.md`, `README.md`, `backend_v2/app/api/main.py`, `backend_v2/app/api/schemas.py`, `backend_v2/tests/unit/test_api_main.py`, `docs/SPECIFICATION.ja.md`, `docs/SPECIFICATION.md`, `frontend_v2/public/api-client.js`, `frontend_v2/public/app.js`, `frontend_v2/public/index.html`.
- Human review required for correctness, security, and licensing.

## Compatibility
- Existing requests continue to default to `command_scope=all`.
- Existing `verify_mode` behavior is preserved and remains scoped to verify commands.

## Checklist
- [x] License header added to new files and top-level LICENSE present
- [x] LLM attribution added to modified/generated files
- [x] Linting completed — score: project checks passed (command: `make check`)
- [x] Tests passing locally (command: `make check`)
- [x] Static analysis/type checks passing (command: `make check`)
- [x] Formatting applied (command: `make check`)
- [x] Pre-commit hooks passing
- [ ] CI green or expected to pass
- [x] No merge conflicts with base branch
- [x] Documentation updated (README, docs/, examples)
- [ ] Changelog/version updated if applicable
- [x] PR description includes summary, rationale, LLM involvement note
- [x] Validation commands listed in PR description
